### PR TITLE
Add support for ECL

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -37,9 +37,9 @@
             (double-float . kernel:double-float-p))
   #+sicl '((single-float . sicl-arithmetic:single-float-p)
            (double-float . sicl-arithmetic:double-float-p))
-  ;; ECL also has long floats
   #+ecl '((single-float . si:single-float-p)
-          (double-float . si:double-float-p))
+          (double-float . si:double-float-p)
+          (long-float . si:long-float-p))
   #-(or clasp sbcl ccl cmucl sicl ecl)
   (error "FLOATS not defined for implementation")
   :test #'equal)
@@ -370,6 +370,7 @@ Discover +standard-charset+ via:
      ;; ECL has si:complex-long-float
      #+ecl ((single-float) (typep ,objectf 'si:complex-single-float))
      #+ecl ((double-float) (typep ,objectf 'si:complex-double-float))
+     #+ecl ((long-float) (typep ,objectf 'si:complex-long-float))
      #-(or clasp sbcl ccl cmucl sicl ecl) ,(error "COMPLEX-UCPTP not defined for implementation")))
 
 ;;;

--- a/config.lisp
+++ b/config.lisp
@@ -122,7 +122,7 @@ Discover +standard-charset+ via:
   #+ccl t
   #+cmucl t
   #+sicl nil
-  #+ecl nil
+  #+ecl t
   #-(or clasp sbcl ccl cmucl sicl ecl)
   (error "COMPLEX-ARRAYS-EXIST-P not defined for implementation"))
 


### PR DESCRIPTION
`typexpand` remains; looking at the ECL 21.2.1 cloned locally, the code looks bad, as this part of the processing does not look to be abstracted out.

We could add a default typexpand function here in CTYPE, but it needs to be generic enough so that it could be used by other implementations lacking typexpand.

In addition, ECL also provides long-float distinct from double-float; should I add support for it here, or do we restrict only to single-float and double-float?