### PR TITLE
Add BIT to SYMBOL-SPECIFIER-CTYPE

### DIFF
--- a/parse.lisp
+++ b/parse.lisp
@@ -264,6 +264,7 @@
     ((bignum) (disjunction
                (range 'integer nil nil (1- most-negative-fixnum) nil)
                (range 'integer (1+ most-positive-fixnum) nil nil nil)))
+    ((bit) (range-ctype 'integer 0 1 env))
     ((bit-vector) (array-ctype :either 'bit '(*) env))
     ((boolean) (cmember nil t))
     ((character) (charset `((0 . ,(1- char-code-limit)))))


### PR DESCRIPTION
On SBCL, `(ctype:specifier-ctype 'bit)` leads to an error:

```lisp
There is no class named COMMON-LISP:BIT.
   [Condition of type SB-PCL:CLASS-NOT-FOUND-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {1001538103}>)

Backtrace:
  0: (SB-PCL::FIND-CLASS-FROM-CELL BIT NIL T)
  1: (CTYPE:SPECIFIER-CTYPE BIT NIL)
```

Neither does [CLHS](http://www.lispworks.com/documentation/lw50/CLHS/Body/04_cg.htm) list BIT to exist as a class. 

Looking at the comments at CTYPE::SYMBOL-SPECIFIER-CTYPE, perhaps BIT was just missed earlier?