### PR TITLE
Improve extended type parsing

### DIFF
--- a/ext/data-structures/array-of.lisp
+++ b/ext/data-structures/array-of.lisp
@@ -7,17 +7,17 @@
   (if simplicity
       (make-instance
        'carray-of
-       :simplicity simplicity :uaet upgraded-element-type :eaet element-ctype :dims dims))
-  (let ((simple
-          (make-instance
-           'carray-of
-           :simplicity :simple :uaet upgraded-element-type :eaet element-ctype :dims dims)))
-    (if ctype:+complex-arrays-exist-p+
-        (disjoin simple
-                 (make-instance
-                  'carray-of
-                  :simplicity :complex :uaet upgraded-element-type :eaet element-ctype :dims dims))
-        simple)))
+       :simplicity simplicity :uaet upgraded-element-type :eaet element-ctype :dims dims)
+      (let ((simple
+              (make-instance
+               'carray-of
+               :simplicity :simple :uaet upgraded-element-type :eaet element-ctype :dims dims)))
+        (if ctype:+complex-arrays-exist-p+
+            (disjoin simple
+                     (make-instance
+                      'carray-of
+                      :simplicity :complex :uaet upgraded-element-type :eaet element-ctype :dims dims))
+            simple))))
 
 (define-extended-type array-of (element-type &optional (dims '*) (upgraded-element-type '*) &environment env)
   :documentation "An array whose elements are of type ELEMENT-TYPE."

--- a/ext/data-structures/hash-table-of.lisp
+++ b/ext/data-structures/hash-table-of.lisp
@@ -40,7 +40,7 @@
         (value2 (value-ctype ctype2)))
     (multiple-value-bind (key-comparison key-valid) (funcall predicate key1 key2)
       (multiple-value-bind (value-comparison value-valid) (funcall predicate value1 value2)
-        (values (funcall combiner (list key-comparison value-comparison))
+        (values (funcall combiner #'identity (list key-comparison value-comparison))
                 (funcall combiner #'identity (list key-valid value-valid)))))))
 
 (defmethod subctypep ((ctype1 chash-table-of) (ctype2 cclass))

--- a/ext/packages.lisp
+++ b/ext/packages.lisp
@@ -6,8 +6,15 @@
   ;; ctypes
   (:export
    #:clist-of
+   #:element-ctype
    #:carray-of
-   #:chash-table-of)
+   #:carray-simplicity
+   #:carray-uaet
+   #:carray-eaet
+   #:carray-dims
+   #:chash-table-of
+   #:key-ctype
+   #:value-ctype)
   ;; extended types
   (:export
    #:list-of

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,6 +1,8 @@
 (defpackage #:ctype
   (:use #:cl)
-  (:export #:specifier-ctype #:extended-specifier-ctype #:values-specifier-ctype)
+  (:export #:specifier-ctype #:values-specifier-ctype
+           #:extended-specifier-ctype
+           #:extended-values-specifier-ctype)
   (:export #:ctypep #:subctypep #:ctype=)
   (:export #:disjointp #:conjointp #:cofinitep)
   (:export #:negate #:conjoin/2 #:disjoin/2 #:subtract #:unparse

--- a/parse.lisp
+++ b/parse.lisp
@@ -557,3 +557,7 @@
   (let ((*parse-extended-types* t))
     (specifier-ctype specifier env)))
 
+(defun extended-values-specifier-ctype (specifier &optional env)
+  "Return the ctype specified by the possibly extended values SPECIFIER."
+  (let ((*parse-extended-types* t))
+    (values-specifier-ctype specifier env)))


### PR DESCRIPTION
- Export readers for *-of extensions

- Add missing identity function argument

- Add and export extended-values-specifier-ctype

- Allow &whole and destructuring in the lambda-list for define-extended-type

- Expand non-extended type aliases when using extended type parsers